### PR TITLE
Add export to Flipper Zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -16,3 +19,4 @@ coverage.xml
 .pytest_cache/
 
 *.log
+output

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ A JSON file (`Xiaomi_TV.json`) will be exported with the following structure as 
         }
     ]
 
+
+Also available export for [Flipper Zero](https://github.com/flipperdevices/flipperzero-firmware)
+
+    $ python -m src db_export -d 1 -f flipper
+
+
 # Developers
 
 Functions are fully documented in the source code according to Python documentation standards;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pycryptodome>=3.5.0
 argparse
 pytest
+requests

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Entry point and argument parser"""
 import argparse
+from itertools import chain
 # Standard imports
 from pathlib import Path
 
@@ -38,7 +39,7 @@ def load_device_codes(device_directory):
 
     :param device_directory: Directory of a device (brands files are stored in it).
     :type device_directory: <str> or <Path>
-    :return: List of Pattern objects (wrappers for decrypted IR codes).
+    :return: List of model objects
     :rtype: <list <Pattern>>
     """
     # Extract encrypted codes from all the models these brands
@@ -52,9 +53,12 @@ def load_device_codes(device_directory):
                 "source": model.get("source", None),
                 "keysetids": model.get("keysetids", None)
             })
+    ir_codes = list(chain(*[chain(*model['ir_codes']) for model in models]))
 
     print("Nb brands:", len(models_per_brand))
     print("Nb models:", len(models))
+    print("Nb Patterns:", len(ir_codes))
+    print("Nb unique patterns:", len(set(ir_codes)))
     return models
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -53,7 +53,7 @@ def load_device_codes(device_directory):
                 "source": model.get("source", None),
                 "keysetids": model.get("keysetids", None)
             })
-    ir_codes = list(chain(*[chain(*model['ir_codes']) for model in models]))
+    ir_codes = list(chain(*[model['ir_codes'] for model in models]))
 
     print("Nb brands:", len(models_per_brand))
     print("Nb models:", len(models))

--- a/src/exports.py
+++ b/src/exports.py
@@ -50,7 +50,7 @@ def tvkill_export(models, export_filename):
     .. note:: Unique patterns are used to reduce overhead.
     """
     patterns = filter(
-        lambda pattern: pattern.id == 'power' or pattern.id == 'shutter',
+        lambda pattern: pattern.id == 'power' or pattern.id == 'shutter' or pattern.id == 'power_r',
         chain(*[model['ir_codes'] for model in models]))
     code_list = [
         {

--- a/src/exports.py
+++ b/src/exports.py
@@ -44,11 +44,14 @@ def load_keyset_codes(directory, keyset):
     return build_patterns(ir_codes)
 
 
-def tvkill_export(patterns, export_filename):
+def tvkill_export(models, export_filename):
     """Export Pattern objects to JSON data for TV Kill app
 
     .. note:: Unique patterns are used to reduce overhead.
     """
+    patterns = filter(
+        lambda pattern: pattern.id == 'power' or pattern.id == 'shutter',
+        chain(*[model['ir_codes'] for model in models]))
     code_list = [
         {
             "comment": "{} {}".format(code.vendor_id, code.model_id),

--- a/src/exports.py
+++ b/src/exports.py
@@ -1,0 +1,43 @@
+import json
+import os
+from pathlib import Path
+
+
+def flipper_export(brands, export_filename):
+    directory = Path(export_filename.replace(" ", "_"))
+    if not directory.exists():
+        directory.mkdir()
+    for brand_per_patterns in brands:
+        content = "Filetype: IR signals file\nVersion: 1"
+        for pattern in brand_per_patterns['ir_codes']:
+            content += "\n#"
+            content += "\nname: " + pattern.id
+            content += "\ntype: raw"
+            content += "\nfrequency: " + str(pattern.frequency)
+            content += "\nduty_cycle: 0.330000"
+            content += "\ndata: " + ' '.join([str(timing) for timing in pattern.to_raw()])
+        path = Path(str(directory) + "/" + brand_per_patterns['brand'] + ".ir")
+        if path.exists():
+            os.remove(path)
+        path.write_text(content)
+
+
+def tvkill_export(patterns, export_filename):
+    """Export Pattern objects to JSON data for TV Kill app
+
+    .. note:: Unique patterns are used to reduce overhead.
+    """
+    code_list = [
+        {
+            "comment": "{} {}".format(code.vendor_id, code.model_id),
+            "frequency": code.frequency,
+            "pattern": code.to_pulses(),
+        }
+        for code in set(patterns)
+    ]
+    tvkill_patterns = {
+        "designation": export_filename,
+        "patterns": code_list,
+    }
+    json_data = json.dumps([tvkill_patterns])  # , indent=2)
+    Path(export_filename.replace(" ", "_") + ".json").write_text(json_data)

--- a/src/exports.py
+++ b/src/exports.py
@@ -18,6 +18,9 @@ def flipper_export(db_directory, models, export_filename):
         if model['keysetids'] is not None:
             patterns += chain(*[load_keyset_codes(db_directory, keyset) for keyset in model['keysetids']])
 
+        if model.get('_id', None) is not None:
+            patterns += chain(*load_keyset_codes(db_directory, model['_id']))
+
         for pattern in patterns:
             content += "\n#\n"
             content += pattern.to_flipper()

--- a/src/pattern.py
+++ b/src/pattern.py
@@ -192,6 +192,15 @@ class Pattern:
         """
         return tuple(self.ir_code)
 
+    def to_flipper(self):
+        content = str()
+        content += "name: " + self.id
+        content += "\ntype: raw"
+        content += "\nfrequency: " + str(self.frequency)
+        content += "\nduty_cycle: 0.330000"
+        content += "\ndata: " + ' '.join([str(timing) for timing in self.to_raw()])
+        return content
+
     def to_signed_raw(self):
         """Raw timmings, positive meaning ON negative meaning OFF
 

--- a/src/pattern.py
+++ b/src/pattern.py
@@ -58,15 +58,17 @@ class Pattern:
     Python sets can be made to ensure the uniqueness of Pattern objects.
     """
 
-    def __init__(self, ir_code, frequency=None, code_type="raw", model_id=None, vendor_id=None):
+    def __init__(self, ir_code, frequency=None, code_type="raw", model_id=None, vendor_id=None, id=None):
         """
         :param ir_code: IR code; Raw timmings by default. If different type,
             set `code_type` argument.
         :key frequency: Optional for Pronto codes only; Mandatory for the others.
         :key code_type: (Optional) `pronto, pulses, raw`. Default: `raw`.
+        :key id: (Optional) name for pattern
         :type ir_code: <Iterable <int>> or <str>
         :type frequency: <int>
         :type code_type: <str>
+        :type id: <str>
         """
         convert_funcs = {
             "pronto": self.from_pronto,
@@ -82,6 +84,7 @@ class Pattern:
         self.code_type = code_type
         self.from_bytes = partial(int.from_bytes, byteorder="big")
         self.ir_code, self.frequency = convert_funcs[code_type](ir_code, frequency)
+        self.id = id
 
     def to_pronto(self):
         """Pronto IR format

--- a/src/xiaomi_parser.py
+++ b/src/xiaomi_parser.py
@@ -270,10 +270,11 @@ def load_brand_codes(filename):
         1 model can have multiple codes including reverse codes.
         We asked power codes so, each code corresponds to this type.
     :type filename: <str>
-    :return: List of dictionnaries corresponding to the definitions of the codes for each model.
+    :return: List of dictionaries corresponding to the definitions of the codes for each model.
         1 dict per model.
-        Used keys from JSON: ir_zip_key, frequency, ir_zip_key, keysetids
-        (internal model id linked to the codes in database), _id, source, power, power_r.
+        Used keys from JSON: frequency, source, _id, keyid, ir_zip_key, ir_zip_key_r
+        Model dictionary is {buttons, (optional) source, (optional) _id, (optional) keysetids}
+        And for button dictionary is {id, ir_zip_key, frequency}
     :rtype: <list <dict>>
     """
 
@@ -387,8 +388,7 @@ def load_brand_codes_from_dir(directory):
 
     .. seealso:: :meth:`load_brand_codes`
 
-    :return: Dict with filenames as keys and list of dictionnaries corresponding
-        to the definitions of the codes as values.
+    :return: Dict with filenames as keys and list of model dictionaries
     :rtype: <dict <str>:<list <dict>>>
     """
     total = 0

--- a/src/xiaomi_parser.py
+++ b/src/xiaomi_parser.py
@@ -288,17 +288,18 @@ def load_brand_codes(filename):
                 for name, ircode in json_model["key"].items()
             ]
 
-            yield buttons, json_model["source"]
+            yield buttons, json_model["source"], json_model["_id"]
 
     json_filedata = json.loads(Path(filename).read_text())
     models = list()
 
     if "others" in json_filedata["data"]:
         # "others" section is not considered for now
-        for other_buttons, source in parse_others_section(json_filedata["data"]["others"]):
+        for other_buttons, source, other_id in parse_others_section(json_filedata["data"]["others"]):
             models.append({
                 'buttons': other_buttons,
-                'source': source
+                'source': source,
+                '_id': other_id
             })
 
     ############################################################################

--- a/src/xiaomi_query.py
+++ b/src/xiaomi_query.py
@@ -190,7 +190,7 @@ def full_process_device(output_directory, json_device_brands_path):
     :type json_device_brands_path: <Path>
     """
     # Load list of brands
-    brands, keysets = load_brand_list(json_device_brands_path)
+    brands = load_brand_list(json_device_brands_path)
     # Query data for all brands if dir is empty
     output_directory.mkdir(exist_ok=True)
     # Download brands
@@ -244,7 +244,7 @@ def dump_database(db_path="./database_dump", *args, **kwargs):
         models_path.mkdir(exist_ok=True)
 
         # TODO: Fix it
-        models = load_brand_codes_from_dir(device_brands_path)
+        models = list(it.chain(*load_brand_codes_from_dir(device_brands_path).values()))
 
         # Only xiaomi models
         mi_models = set(

--- a/src/xiaomi_query.py
+++ b/src/xiaomi_query.py
@@ -23,7 +23,7 @@ from random import shuffle
 
 # Custom imports
 from .crypt_utils import build_url
-from .xiaomi_parser import load_devices, load_brand_list, load_brand_codes_from_dir, build_patterns
+from .xiaomi_parser import load_devices, load_brand_list, load_brand_codes_from_dir
 
 
 def get_json_devices():
@@ -246,6 +246,7 @@ def dump_database(db_path="./database_dump", *args, **kwargs):
         device_name = device["name"]
         device_brands_path = Path(f"{db_path}/{device_id}_{device_name}")
 
+        # TODO: fix query
         # Only xiaomi models
         models = list(it.chain(*load_brand_codes_from_dir(device_brands_path).values()))
         mi_models = set(

--- a/src/xiaomi_query.py
+++ b/src/xiaomi_query.py
@@ -190,7 +190,7 @@ def full_process_device(output_directory, json_device_brands_path):
     :type json_device_brands_path: <Path>
     """
     # Load list of brands
-    brands = load_brand_list(json_device_brands_path)
+    brands, keysets = load_brand_list(json_device_brands_path)
     # Query data for all brands if dir is empty
     output_directory.mkdir(exist_ok=True)
     # Download brands
@@ -243,12 +243,10 @@ def dump_database(db_path="./database_dump", *args, **kwargs):
         models_path = device_brands_path / "models/"
         models_path.mkdir(exist_ok=True)
 
-        device_name = device["name"]
-        device_brands_path = Path(f"{db_path}/{device_id}_{device_name}")
+        # TODO: Fix it
+        models = load_brand_codes_from_dir(device_brands_path)
 
-        # TODO: fix query
         # Only xiaomi models
-        models = list(it.chain(*load_brand_codes_from_dir(device_brands_path).values()))
         mi_models = set(
             it.chain(*[model["keysetids"] for model in models if "keysetids" in model])
         )

--- a/src/xiaomi_query.py
+++ b/src/xiaomi_query.py
@@ -243,7 +243,6 @@ def dump_database(db_path="./database_dump", *args, **kwargs):
         models_path = device_brands_path / "models/"
         models_path.mkdir(exist_ok=True)
 
-        # TODO: Fix it
         models = list(it.chain(*load_brand_codes_from_dir(device_brands_path).values()))
 
         # Only xiaomi models


### PR DESCRIPTION
Main goal of this pr is add new export type - `flipper` for Flipper Zero

But I have some problem with passing other keys from `load_brand_codes` - right now parser ignore the button which does not just power on/off the device

# Changes
- `load_brand_codes` right now return all keys which available for this brand
-  Add new export - `flipper`

# How to test
I tested:
- Full download (from zero)
- Partial download
- TVKill export
- Flipper Zero export