### PR TITLE
Always explicitely use utf-8 when reading/writing files

### DIFF
--- a/src/commons.py
+++ b/src/commons.py
@@ -64,6 +64,7 @@ file_handler = RotatingFileHandler(
     "a",
     100_000_000,
     1,
+    encoding="utf-8"
 )
 file_handler.setLevel(LOG_LEVEL)
 file_handler.setFormatter(formatter)

--- a/src/writers/flipper_zero.py
+++ b/src/writers/flipper_zero.py
@@ -80,4 +80,4 @@ Version: 1
 
         # Dump
         path = Path(output) / f"{brand}_{model_id}.ir"
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")

--- a/src/writers/tvkill.py
+++ b/src/writers/tvkill.py
@@ -64,4 +64,4 @@ def tvkill_export(patterns, output, device_name):
 
     # Build export filename based on device name
     export_filename = "TVKill_Xiaomi_" + device_name
-    Path(output, export_filename.replace(" ", "_") + ".json").write_text(json_data)
+    Path(output, export_filename.replace(" ", "_") + ".json").write_text(json_data, encoding="utf-8")

--- a/src/xiaomi_parser.py
+++ b/src/xiaomi_parser.py
@@ -49,7 +49,7 @@ def load_devices(filename):
         device description as values.
     :rtype: <dict <int>: <dict>>
     """
-    json_filedata = json.loads(Path(filename).read_text())
+    json_filedata = json.loads(Path(filename).read_text(encoding="utf-8"))
     devices = dict()
 
     for json_device in json_filedata["data"]:
@@ -170,7 +170,7 @@ def load_brand_list(filename):
         Used keys from JSON: brandid, deviceid, name
     :rtype: <dict <int>:<dict>>
     """
-    json_filedata = json.loads(Path(filename).read_text())
+    json_filedata = json.loads(Path(filename).read_text(encoding="utf-8"))
 
     brands = dict()
     json_brands = json_filedata["data"]
@@ -217,7 +217,7 @@ def load_stp_brand_list(filename):
         Used keys from JSON: brandid, deviceid, name
     :rtype: <dict <str>:<dict>>
     """
-    json_filedata = json.loads(Path(filename).read_text())
+    json_filedata = json.loads(Path(filename).read_text(encoding="utf-8"))
 
     brands = dict()
     json_brands = json_filedata["data"]["data"]
@@ -370,7 +370,7 @@ def load_brand_codes(filename):
 
             yield model
 
-    json_filedata = json.loads(Path(filename).read_text())
+    json_filedata = json.loads(Path(filename).read_text(encoding="utf-8"))
     models = list()
 
     if "others" in json_filedata["data"]:
@@ -499,7 +499,7 @@ def build_all_patterns(brands_data, models_path, keys=tuple()):
             filepath = models_path / (model_id + ".json")
             if not filepath.exists():
                 continue
-            json_filedata = json.loads(filepath.read_text())
+            json_filedata = json.loads(filepath.read_text(encoding="utf-8"))
 
             data = json_filedata["data"]
             if not data:
@@ -558,7 +558,7 @@ def get_vendors_model_ids(brand_filepath):
         'mi' vendor should be set most of the time but not guaranteed.
     :rtype: <dict <str>: <set>>
     """
-    json_filedata = json.loads(Path(brand_filepath).read_text())
+    json_filedata = json.loads(Path(brand_filepath).read_text(encoding="utf-8"))
 
     data = json_filedata["data"]
     model_ids = defaultdict(set)

--- a/src/xiaomi_query.py
+++ b/src/xiaomi_query.py
@@ -150,7 +150,7 @@ def crawl_brands(output_directory, brands, stb=False):
         json_data = get_json_brand(brand_id, device_id, stb=stb)
 
         # Dump the result
-        filepath.write_text(json_data)
+        filepath.write_text(json_data, encoding="utf-8")
 
         LOGGER.info("Done: %s", brand_id)
         # Do not be too harsh with the server...
@@ -187,7 +187,7 @@ def crawl_models(output_directory, model_ids, vendorid="mi"):
         json_data = get_json_model(model_id, vendorid=vendorid)
 
         # Dump the result
-        filepath.write_text(json_data)
+        filepath.write_text(json_data, encoding="utf-8")
 
         LOGGER.debug("Done: %s", model_id)
         # Do not be too harsh with the server...
@@ -233,7 +233,7 @@ def dump_database(*_args, db_path="./database_dump", **_kwargs):
     # Get all devices
     json_devices_path = Path(f"{db_path}/devices.json")
     if not json_devices_path.is_file():
-        Path(json_devices_path).write_text(get_json_devices())
+        Path(json_devices_path).write_text(get_json_devices(), encoding="utf-8")
 
     # Data ex: {1: {'name': 'TV'}, ...}
     devices = load_devices(json_devices_path)
@@ -251,7 +251,7 @@ def dump_database(*_args, db_path="./database_dump", **_kwargs):
                 json_data = get_json_stb_brands()
             else:
                 json_data = get_json_brands(device_id)
-            Path(json_device_brands_path).write_text(json_data)
+            Path(json_device_brands_path).write_text(json_data, encoding="utf-8")
 
         device_brands_path = Path(f"{db_path}/{device_id}_{device_name}")
         device_brands_path.mkdir(exist_ok=True)


### PR DESCRIPTION

    Explicitely pass utf-8 as an encoding to fix the following errors in Windows.

    UnicodeEncodeError: 'charmap' codec can't encode characters in position 106-108: character maps to <undefined>
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 2514: character maps to <undefined>

    It uses the locale encoding by default otherwise which is probably
    not what we want when generating files, and also explodes with Unicode
    on Windows.

    Note: Missing encoding arguments can be detected on all platforms starting with
    Python 3.10 if the PYTHONWARNDEFAULTENCODING env var is set, see
    https://peps.python.org/pep-0597 for more details.

