### PR TITLE
Fix checking odd number of IR burst pairs

### DIFF
--- a/src/pattern.py
+++ b/src/pattern.py
@@ -105,7 +105,7 @@ class Pattern:
         ir_code = [to_padded_hex(i) for i in self.to_pulses()]
 
         # Bursts should be a multiple of 2: Burst pairs (On/Off)
-        if len(ir_code) % 2 == 0:
+        if len(ir_code) % 2 != 0:
             print("WARNING: Burst pairs are not complete: odd number")
 
         # Try to detect number and size of sequences

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -53,7 +53,7 @@ def test_to_pulses(ir_code, pulse_code):
         _ = Pattern(ir_code, code_type="raw")
 
 
-def test_to_pronto(ir_code, pronto_code):
+def test_to_pronto(ir_code, pronto_code, capsys):
     """Test conversion and ability to detect 2 sequences in IR pulses"""
     pattern = Pattern(ir_code, 37990, code_type="raw")
     print(pattern)
@@ -61,6 +61,14 @@ def test_to_pronto(ir_code, pronto_code):
 
     print(found)
     assert pronto_code == found
+
+    # Test Odd number of burst values
+    ir_code.pop()
+    pattern = Pattern(ir_code, 37990, code_type="raw")
+    found = pattern.to_pronto()
+    captured = capsys.readouterr()
+    print(found)
+    assert "Burst pairs are not complete" in captured.out
 
 
 def test_to_signed_raw(ir_code):


### PR DESCRIPTION
Example:

```python
>>> ir_code = [9042,4484,579,552,580,567,579,567,544,554]
>>> pattern = Pattern(ir_code, 37990, code_type="raw")
>>> pattern.to_pronto()
WARNING: Burst pairs are not complete: odd number
'0000 006D 0005 0000 0158 00AA 0016 0015 0016 0016 0016 0016 0015 0015'
>>> len(ir_code)
10
```
