### PR TITLE
Remove newline character from brand names

### DIFF
--- a/src/xiaomi_parser.py
+++ b/src/xiaomi_parser.py
@@ -183,7 +183,7 @@ def load_brand_list(filename):
         device_id = brand["deviceid"]
         # print(brand_name, brand_id, type(brand_id))
         brands[brand_id] = {
-            "name": brand_name,
+            "name": brand_name.replace("\n", ""),
             "deviceid": device_id,
         }
     return brands


### PR DESCRIPTION

    Some brand name contains newline character (\n) in json files.
    This change removes those newline character and fixes the following error.

    OSError: [Errno 22] Invalid argument: 'database_dump/1_TV/Conrowa\n_584.json'
    OSError: [Errno 22] Invalid argument: 'database_dump/3_AC/Conrowa\n_584.json'

